### PR TITLE
LM interpolation

### DIFF
--- a/data/lm/generate_lm.py
+++ b/data/lm/generate_lm.py
@@ -92,8 +92,6 @@ def build_lm(args, data_lower, vocab_str):
         lm_path,
         "--prune",
         *args.arpa_prune.split("|"),
-        "--intermediate",
-        "small",
     ]
     if args.discount_fallback:
         subargs += ["--discount_fallback"]

--- a/data/lm/generate_lm.py
+++ b/data/lm/generate_lm.py
@@ -92,6 +92,8 @@ def build_lm(args, data_lower, vocab_str):
         lm_path,
         "--prune",
         *args.arpa_prune.split("|"),
+        "--intermediate",
+        "small",
     ]
     if args.discount_fallback:
         subargs += ["--discount_fallback"]

--- a/data/lm/interpolate_lm.py
+++ b/data/lm/interpolate_lm.py
@@ -84,6 +84,21 @@ def interpolate(args):
 
     return interpolated_lm_arpa
 
+def create_combined_vocabulary(args):
+
+    combined_vocab = set()
+    combined_vocab_path = os.path.join(args.output_dir, "{}_vocab.txt".format(args.name[0]))
+
+    for idx in range(len(args.input_txts)):
+        vocab_path = os.path.join(args.output_dir, "{}_lm.vocab".format(idx))
+        with open(vocab_path) as f:
+            vocab = f.read()
+        vocab = vocab.split("\x00")
+        combined_vocab |= set(vocab)
+
+    with open(combined_vocab_path, "w") as f:
+        f.write(" ".join(combined_vocab))
+
 def binarize_lm(args, interpolated_lm_arpa):
 
     # Quantize and produce trie binary.
@@ -185,6 +200,7 @@ def main():
 
     interpolated_lm_arpa = interpolate(args)
     binarize_lm(args, interpolated_lm_arpa)
+    create_combined_vocabulary(args)
 
 if __name__ == "__main__":
     main()

--- a/data/lm/interpolate_lm.py
+++ b/data/lm/interpolate_lm.py
@@ -1,0 +1,184 @@
+import argparse
+import gzip
+import io
+import os
+import subprocess
+from collections import Counter
+
+import progressbar
+from clearml import Task
+
+
+def convert_text(idx, input_txt, output_dir):
+
+    data_lower = os.path.join(output_dir, "{}_lower.txt.gz".format(idx))
+
+    print("\nConverting to lowercase and counting word occurrences ...")
+    with io.TextIOWrapper(
+        io.BufferedWriter(gzip.open(data_lower, "w+")), encoding="utf-8"
+    ) as file_out:
+
+        # Open the input file either from input.txt or input.txt.gz
+        _, file_extension = os.path.splitext(input_txt)
+        if file_extension == ".gz":
+            file_in = io.TextIOWrapper(
+                io.BufferedReader(gzip.open(input_txt)), encoding="utf-8"
+            )
+        else:
+            file_in = open(input_txt, encoding="utf-8")
+
+        for line in progressbar.progressbar(file_in):
+            line_lower = line.lower()
+            counter.update(line_lower.split())
+            file_out.write(line_lower)
+
+        file_in.close()
+
+    return data_lower
+
+def build_intermediate_lm(args, idx, data_lower):
+    print("\nCreating ARPA file ...")
+    lm_path = os.path.join(args.output_dir, "{}_lm.arpa".format(idx))
+    intermediate_lm_path = os.path.join(args.output_dir, "{}_lm".format(idx))
+    subargs = [
+        os.path.join(args.kenlm_bins, "lmplz"),
+        "--order",
+        str(args.arpa_order),
+        "--temp_prefix",
+        args.output_dir,
+        "--memory",
+        args.max_arpa_memory,
+        "--text",
+        data_lower,
+        "--arpa",
+        lm_path,
+        "--prune",
+        *args.arpa_prune.split("|"),
+        "--intermediate",
+        intermediate_lm_path,
+    ]
+
+    # if args.discount_fallback:
+    #     subargs += ["--discount_fallback"]
+
+    subprocess.check_call(subargs)
+
+    return intermediate_lm_path
+
+def binarize_lm(args, interpolated_lm_arpa):
+
+	# Quantize and produce trie binary.
+    print("\nBuilding interpolated_lm.binary ...")
+    binary_path = os.path.join(args.output_dir, "interpolated_lm.binary")
+    subprocess.check_call(
+        [
+            os.path.join(args.kenlm_bins, "build_binary"),
+            "-a",
+            str(args.binary_a_bits),
+            "-q",
+            str(args.binary_q_bits),
+            "-v",
+            args.binary_type,
+            interpolated_lm_arpa,
+            binary_path,
+        ]
+    )
+    print("\nBinary file written to {}".format(binary_path))
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate an interpolated language model from multiple corpora."
+    )
+    parser.add_argument(
+        "--input_txts",
+        help="Paths to file.txt or file.txt.gz with sample sentences",
+        type=str,
+        required=True,
+        nargs="+"
+    )
+    parser.add_argument(
+        "--weights",
+        help="Weights to use for input LMs when interpolating",
+        type=str,
+        required=True,
+        nargs="+"
+    )
+    parser.add_argument(
+        "--name",
+        help="Name to use for writing interpolated LM files",
+        type=str,
+        required=True
+        nargs=1
+    )
+    parser.add_argument(
+        "--kenlm_bins",
+        help="File path to the KENLM binaries lmplz, filter and build_binary",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--arpa_order",
+        help="Order of k-grams in ARPA-file generation",
+        type=int,
+        required=True,
+    )
+    parser.add_argument(
+        "--max_arpa_memory",
+        help="Maximum allowed memory usage for ARPA-file generation",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--arpa_prune",
+        help="ARPA pruning parameters. Separate values with '|'",
+        type=str,
+        required=True,
+    )
+    parser.add_argument(
+        "--binary_a_bits",
+        help="Build binary quantization value a in bits",
+        type=int,
+        required=True,
+    )
+    parser.add_argument(
+        "--binary_q_bits",
+        help="Build binary quantization value q in bits",
+        type=int,
+        required=True,
+    )
+    parser.add_argument(
+        "--binary_type",
+        help="Build binary data structure type",
+        type=str,
+        required=True,
+    )
+
+	args = parser.parse_args()
+	assert len(args.input_txts) == len(args.weights)
+
+	intermediate_lms = []
+
+	for idx, vals in enumerate(zip(args.input_txts, args.weights)):
+		input_txt, weight = vals
+		data_lower = convert_text(idx, input_txt, args.output_dir)
+		intermediate_lm_path = build_intermediate_lm(args, idx, data_lower)
+		intermediate_lms.append(intermediate_lm_path)
+
+	interpolated_lm_arpa = os.path.join(output_dir, "{}.arpa".format(args.name))
+
+	subargs = [
+		os.path.join(args.kenlm_bins, "interpolate"),
+		"--models",
+		" ".join(intermediate_lms),
+		"--weights",
+		" ".join(args.weights),
+	]
+
+	subprocess.check_call(subargs, stdout=interpolated_lm_arpa)
+
+	# will skip arpa file filtering for now
+	# need some logic to include all ngrams from customer data
+	# and filter out ngrams past some threshold for other data
+
+	binarize_lm(args, interpolated_lm_arpa)
+

--- a/data/lm/interpolate_lm.py
+++ b/data/lm/interpolate_lm.py
@@ -3,10 +3,8 @@ import gzip
 import io
 import os
 import subprocess
-from collections import Counter
 
 import progressbar
-from clearml import Task
 
 def convert_text(idx, input_txt, output_dir):
 
@@ -90,7 +88,7 @@ def binarize_lm(args, interpolated_lm_arpa):
 
     # Quantize and produce trie binary.
     print("\nBuilding interpolated_lm.binary ...")
-    binary_path = os.path.join(args.output_dir, "interpolated_lm.binary")
+    binary_path = os.path.join(args.output_dir, "{}_interpolated_lm.binary".format(args.name[0]))
     subprocess.check_call(
         [
             os.path.join(args.kenlm_bins, "build_binary"),

--- a/data/lm/interpolate_lm.py
+++ b/data/lm/interpolate_lm.py
@@ -13,7 +13,7 @@ def convert_text(idx, input_txt, output_dir):
 
     data_lower = os.path.join(output_dir, "{}_lower.txt.gz".format(idx))
 
-    print("\nConverting to lowercase and counting word occurrences ...")
+    print("\nConverting to lowercase ...")
     with io.TextIOWrapper(
         io.BufferedWriter(gzip.open(data_lower, "w+")), encoding="utf-8"
     ) as file_out:
@@ -29,7 +29,6 @@ def convert_text(idx, input_txt, output_dir):
 
         for line in progressbar.progressbar(file_in):
             line_lower = line.lower()
-            counter.update(line_lower.split())
             file_out.write(line_lower)
 
         file_in.close()
@@ -67,7 +66,7 @@ def build_intermediate_lm(args, idx, data_lower):
 
 def binarize_lm(args, interpolated_lm_arpa):
 
-	# Quantize and produce trie binary.
+    # Quantize and produce trie binary.
     print("\nBuilding interpolated_lm.binary ...")
     binary_path = os.path.join(args.output_dir, "interpolated_lm.binary")
     subprocess.check_call(
@@ -90,6 +89,16 @@ def main():
         description="Generate an interpolated language model from multiple corpora."
     )
     parser.add_argument(
+        "--name",
+        help="Name to use for writing interpolated LM files",
+        type=str,
+        required=True,
+        nargs=1
+    )
+    parser.add_argument(
+        "--output_dir", help="Directory path for the output", type=str, required=True
+    )
+    parser.add_argument(
         "--input_txts",
         help="Paths to file.txt or file.txt.gz with sample sentences",
         type=str,
@@ -102,13 +111,6 @@ def main():
         type=str,
         required=True,
         nargs="+"
-    )
-    parser.add_argument(
-        "--name",
-        help="Name to use for writing interpolated LM files",
-        type=str,
-        required=True
-        nargs=1
     )
     parser.add_argument(
         "--kenlm_bins",
@@ -153,32 +155,43 @@ def main():
         required=True,
     )
 
-	args = parser.parse_args()
-	assert len(args.input_txts) == len(args.weights)
+    args = parser.parse_args()
+    assert len(args.input_txts) == len(args.weights)
 
-	intermediate_lms = []
+    intermediate_lms = []
 
-	for idx, vals in enumerate(zip(args.input_txts, args.weights)):
-		input_txt, weight = vals
-		data_lower = convert_text(idx, input_txt, args.output_dir)
-		intermediate_lm_path = build_intermediate_lm(args, idx, data_lower)
-		intermediate_lms.append(intermediate_lm_path)
+    for idx, vals in enumerate(zip(args.input_txts, args.weights)):
+        input_txt, weight = vals
+        data_lower = convert_text(idx, input_txt, args.output_dir)
+        intermediate_lm_path = build_intermediate_lm(args, idx, data_lower)
+        intermediate_lms.append(intermediate_lm_path)
 
-	interpolated_lm_arpa = os.path.join(output_dir, "{}.arpa".format(args.name))
+    interpolated_lm_arpa = os.path.join(args.output_dir, "{}.arpa".format(args.name[0]))
 
-	subargs = [
-		os.path.join(args.kenlm_bins, "interpolate"),
-		"--models",
-		" ".join(intermediate_lms),
-		"--weights",
-		" ".join(args.weights),
-	]
+    subargs = [
+        os.path.join(args.kenlm_bins, "interpolate"),
+        "-m",
+        " ".join(intermediate_lms),
+        "-w",
+        " ".join(args.weights),
+    ]
+ 
+    interpolate_cmd = "{} -m {} -w {}".format(
+        os.path.join(args.kenlm_bins, "interpolate"),
+        " ".join(intermediate_lms),
+        " ".join(args.weights)
+        )
 
-	subprocess.check_call(subargs, stdout=interpolated_lm_arpa)
+    print(interpolate_cmd)
+    with open(interpolated_lm_arpa, "w") as f:
+        #subprocess.check_call(subargs, shell=True,  stdout=f)
+        subprocess.check_call(interpolate_cmd, shell=True, stdout=f)
 
-	# will skip arpa file filtering for now
-	# need some logic to include all ngrams from customer data
-	# and filter out ngrams past some threshold for other data
+    # will skip arpa file filtering for now
+    # need some logic to include all ngrams from customer data
+    # and filter out ngrams past some threshold for other data
 
-	binarize_lm(args, interpolated_lm_arpa)
+    binarize_lm(args, interpolated_lm_arpa)
 
+if __name__ == "__main__":
+    main()

--- a/data/lm/interpolate_lm.py
+++ b/data/lm/interpolate_lm.py
@@ -86,6 +86,8 @@ def interpolate(args):
 
 def create_combined_vocabulary(args):
 
+    print("\nCreating combined vocabulary file from constituent LMs...")
+
     combined_vocab = set()
     combined_vocab_path = os.path.join(args.output_dir, "{}_vocab.txt".format(args.name[0]))
 
@@ -98,6 +100,8 @@ def create_combined_vocabulary(args):
 
     with open(combined_vocab_path, "w") as f:
         f.write(" ".join(combined_vocab))
+
+    print("\nWrote combined vocabulary file to {}".format(combined_vocab_path))
 
 def binarize_lm(args, interpolated_lm_arpa):
 


### PR DESCRIPTION
This PR creates a new script `interpolate_lm.py` to interpolate a language model from 2 or more text files and associated weights. It is based on the existing Coqui script `generate_lm.py`.

The new script generates an "intermediate" LM for each input text, and then combines them all by calling the `interpolate` method from `kenlm`. Then it binarizes the LM and creates a vocabulary file from the constituent vocabulary files. The binary and vocab files are needed for using `generate_scorer_package`.

I have tested this script with multiple commands (example below), and successfully generated a scorer from the resulting binary and vocab files.

An example command:

```
python interpolate_lm.py \
  --name test1 \
  --output_dir /home/ubuntu/interpolation_tests \
  --input_txts /mnt/efs/language_models/en/customer_data_large/train_transcript.txt /mnt/efs/language_models/en/customer_data_small/train_transcript.txt \
  --weights 0.5 0.5 \
  --kenlm_bins /home/ubuntu/kenlm/build/bin \
  --arpa_order 5 \
  --max_arpa_memory "85%" \
  --arpa_prune "0|0|1" \
  --binary_a_bits 255 \
  --binary_q_bits 8 \
  --binary_type trie
```

This command would write the LM binary to a file called `test1_interpolated_lm.binary` and write the vocab file to `test1_vocab.txt`. The prefix `test1` is the `name` argument passed to the script.

Currently this script doesn't support filtering the vocabulary. Based on our vocab size this doesn't seem urgent, but we can add it in later if we need to.